### PR TITLE
ci: add basic presubmits

### DIFF
--- a/.github/workflows/presubmit-tests.yml
+++ b/.github/workflows/presubmit-tests.yml
@@ -28,4 +28,4 @@ jobs:
         run: npm install @google/gemini-cli
 
       - name: Install AlloyDB Extension
-        run: npx gemini extensions install --path=./abc
+        run: npx gemini extensions install --path=.


### PR DESCRIPTION
This workflow runs the basics of extension installation. Loading extensions might require Cloud Resources and can be added in the future if required.