### PR TITLE
docs: include mirror changelog info in developer docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -106,7 +106,10 @@ The release process is automated using `release-please`. It consists of an autom
 
 #### Automated Changelog Enrichment
 
-Before a Release PR is even created, a special workflow automatically mirrors relevant changelogs from the core `googleapis/genai-toolbox` dependency. This ensures that the release notes for this extension accurately reflect important upstream changes.
+Before a Release PR is even created, a special workflow automatically mirrors
+relevant changelogs from the core `googleapis/genai-toolbox` dependency. This
+ensures that the release notes for this extension accurately reflect important
+upstream changes.
 
 The process is handled by the [`mirror-changelog.yml`](.github/workflows/mirror-changelog.yml) workflow:
 
@@ -114,11 +117,9 @@ The process is handled by the [`mirror-changelog.yml`](.github/workflows/mirror-
    Renovate for `toolbox` version updates.
 2. **Parsing:** It reads the detailed release notes that Renovate includes in
    the PR body.
-3. **Filtering:** A Node.js script located at
-   [`.github/scripts/mirror-changelog.js`](.github/scripts/mirror-changelog.js)
-   filters these release notes to include only changes relevant to this
-   extension. The relevance is determined by a keyword (e.g., `alloydb`), passed
-   as an environment variable in the workflow file.
+3. **Filtering:** These release notes are filtered to include only changes
+   relevant to this extension. The relevance is determined by a keyword (e.g.,
+   `alloydb`), passed as an environment variable in the workflow file.
 4. **Changelog Injection:** The script formats the filtered entries as
    conventional commits and injects them into the PR body within a
    `BEGIN_COMMIT_OVERRIDE` block.


### PR DESCRIPTION
Link checker is failing because https://github.com/gemini-cli-extensions/alloydb/pull/75 is not pushed yet. Should pass once those files are in.