### PR TITLE
ci: auto run assign PR workflow

### DIFF
--- a/.github/workflows/assign-prs.yml
+++ b/.github/workflows/assign-prs.yml
@@ -16,7 +16,7 @@ name: PR assignment
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened]
 
 jobs:
   auto-assign:


### PR DESCRIPTION
Tested.

- Does not work directly if a PR is converted from `Draft` to `Ready for review`. However, users can edit their PR title or description to trigger the workflow.
- The `edited` event triggers the workflow on any changes in the PR title or description.
- Removed the synchronized event. This event triggers the action on any code changes in the PR. This is often unecessary and causes wastage of resources.