### PR TITLE
ci: add release-please label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -83,4 +83,4 @@
 
 - name: 'release-please:force-run'
   color: bdca82
-  description: To run release-please
+  description: Manually trigger the release please workflow on a PR.


### PR DESCRIPTION
Copied colour from https://github.com/googleapis/google-cloud-java/labels?q=release-please since it is the example provided [here](https://github.com/googleapis/release-please/blob/main/docs/troubleshooting.md#what-if-my-release-pr-is-merged-with-autoreleaseclosed).