### PR TITLE
docs: update developer docs to link local extension without installing

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -44,7 +44,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     # The `chmod` command is not required on Windows.
     ```
 
-3.  **Install the Extension Locally:** Use the Gemini CLI to install the
+3.  **Link the Extension Locally:** Use the Gemini CLI to link the
     extension from your local directory.
 
     ```bash
@@ -52,7 +52,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     ```
     The CLI will prompt you to confirm the installation. Accept it to proceed.
 
-4.  **Testing Changes:** After installation, start the Gemini CLI (`gemini`).
+4.  **Testing Changes:** After linking, start the Gemini CLI (`gemini`).
     You can now interact with the `alloydb` tools to manually test your changes
     against your connected database.
 


### PR DESCRIPTION
Replicates the intent of gemini-cli-extensions/cloud-sql-postgresql#107 for alloydb by updating the documentation phrasing from 'Install' to 'Link', clarifying the `gemini extensions link .` process.